### PR TITLE
Empty _callback event listeners are removed

### DIFF
--- a/socket.io.js
+++ b/socket.io.js
@@ -1192,6 +1192,12 @@ Emitter.prototype.removeEventListener = function(event, fn){
     cb = callbacks[i];
     if (cb === fn || cb.fn === fn) {
       callbacks.splice(i, 1);
+
+      //check if there are any handlers left for the events callbacks, if not, delete the entry
+      if(callbacks.length == 0){
+          delete this._callbacks[event];
+      }
+
       break;
     }
   }


### PR DESCRIPTION
When a specific callback listener was removed from a socket, the event listener could contain no callbacks. This code checks if the listener array has any callbacks on it after the specific callback is remove, if it doesn't have any other callbacks the listener is removed . 