### PR TITLE
fix url parsing when uri string is undefined

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -26,7 +26,7 @@ function url(uri, loc){
 
   // default to window.location
   var loc = loc || global.location;
-  if (null == uri) uri = loc.protocol + '//' + loc.hostname;
+  if (null == uri) uri = loc.protocol + '//' + loc.host;
 
   // relative path support
   if ('string' == typeof uri) {

--- a/test/url.js
+++ b/test/url.js
@@ -6,6 +6,17 @@ var expect = require('expect.js');
 
 describe('url', function(){
 
+  it('works with undefined', function(){
+    loc.hostname = 'woot.com';
+    loc.protocol = 'https:';
+    loc.port = 4005;
+    loc.host = loc.hostname + ':' + loc.port;
+    var parsed = url(undefined, loc);
+    expect(parsed.host).to.be('woot.com');
+    expect(parsed.protocol).to.be('https');
+    expect(parsed.port).to.be('4005');
+  });
+
   it('works with relative paths', function(){
     loc.hostname = 'woot.com';
     loc.protocol = 'https:';


### PR DESCRIPTION
The url parser was ignoring port hints from window.location when the uri
string was undefined. This commit changes the parser to use
window.location.host (not hostname) so that the port is preserved.