### PR TITLE
Fix port hint

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -34,7 +34,7 @@ function url(uri, loc){
       if ('/' == uri.charAt(1)) {
         uri = loc.protocol + uri;
       } else {
-        uri = loc.hostname + uri;
+        uri = loc.host + uri;
       }
     }
 

--- a/test/url.js
+++ b/test/url.js
@@ -19,9 +19,12 @@ describe('url', function(){
   it('works with relative paths', function(){
     loc.hostname = 'woot.com';
     loc.protocol = 'https:';
+    loc.port = 3000;
+    loc.host = loc.hostname + ':' + loc.port;
     var parsed = url('/test', loc);
     expect(parsed.host).to.be('woot.com');
     expect(parsed.protocol).to.be('https');
+    expect(parsed.port).to.be('3000');
   });
 
   it('works with no protocol', function(){


### PR DESCRIPTION
The URL parser was ignoring port hints from window.location when the uri string was relative path.

This commit changes the parser to use window.location.host.