### PR TITLE
Support compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ A property on the `socket` instance that is equal to the underlying engine.io so
 
 The property is present once the socket has connected, is removed when the socket disconnects and is updated if the socket reconnects.
 
+#### Socket#compress(v:Boolean):Socket
+
+  Sets a modifier for a subsequent event emission that the event data will
+  only be _compressed_ if the value is `true`. Defaults to `true` when you don't call the method.
+
+  ```js
+  socket.compress(false).emit('an event', { some: 'data' });
+  ```
+
 #### Events
 
   - `connect`. Fired upon a connection including a successful reconnection.

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -365,7 +365,7 @@ Manager.prototype.packet = function(packet){
     self.encoding = true;
     this.encoder.encode(packet, function(encodedPackets) {
       for (var i = 0; i < encodedPackets.length; i++) {
-        self.engine.write(encodedPackets[i]);
+        self.engine.write(encodedPackets[i], packet.options);
       }
       self.encoding = false;
       self.processPacketQueue();

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -135,6 +135,9 @@ Socket.prototype.emit = function(ev){
   if (hasBin(args)) { parserType = parser.BINARY_EVENT; } // binary
   var packet = { type: parserType, data: args };
 
+  packet.options = {}
+  packet.options.compress = !this.flags || false !== this.flags.compress;
+
   // event ack callback
   if ('function' == typeof args[args.length - 1]) {
     debug('emitting packet with ack id %d', this.ids);
@@ -147,6 +150,8 @@ Socket.prototype.emit = function(ev){
   } else {
     this.sendBuffer.push(packet);
   }
+
+  delete this.flags;
 
   return this;
 };
@@ -174,7 +179,7 @@ Socket.prototype.onopen = function(){
 
   // write connect packet if necessary
   if ('/' != this.nsp) {
-    this.packet({ type: parser.CONNECT });
+    this.packet({ type: parser.CONNECT, options: { compress: true } });
   }
 };
 
@@ -277,7 +282,8 @@ Socket.prototype.ack = function(id){
     self.packet({
       type: type,
       id: id,
-      data: args
+      data: args,
+      options: { compress: true }
     });
   };
 };
@@ -371,7 +377,7 @@ Socket.prototype.close =
 Socket.prototype.disconnect = function(){
   if (this.connected) {
     debug('performing disconnect (%s)', this.nsp);
-    this.packet({ type: parser.DISCONNECT });
+    this.packet({ type: parser.DISCONNECT, options: { compress: true } });
   }
 
   // remove socket from pool
@@ -381,5 +387,19 @@ Socket.prototype.disconnect = function(){
     // fire events
     this.onclose('io client disconnect');
   }
+  return this;
+};
+
+/**
+ * Sets the compress flag.
+ *
+ * @param {Boolean} if `true`, compresses the sending data
+ * @return {Socket} self
+ * @api public
+ */
+
+Socket.prototype.compress = function(compress){
+  this.flags = this.flags || {};
+  this.flags.compress = compress;
   return this;
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "debug": "0.7.4",
-    "engine.io-client": "1.5.1",
+    "engine.io-client": "Automattic/engine.io-client#599021ff1e71f7242f30fa71a6a3481ec1021ba4",
     "component-bind": "1.0.0",
     "component-emitter": "1.1.2",
     "object-component": "0.0.3",

--- a/test/socket.js
+++ b/test/socket.js
@@ -42,4 +42,28 @@ describe('socket', function(){
       socket.io.engine.close();
     });
   });
+
+  it('should enable compression by default', function(done){
+    var socket = io({ forceNew: true });
+    socket.on('connect', function(){
+      socket.io.engine.once('packetCreate', function(packet){
+        expect(packet.options.compress).to.be(true);
+        socket.disconnect();
+        done();
+      });
+      socket.emit('hi');
+    });
+  });
+
+  it('should disable compression', function(done){
+    var socket = io({ forceNew: true });
+    socket.on('connect', function(){
+      socket.io.engine.once('packetCreate', function(packet){
+        expect(packet.options.compress).to.be(false);
+        socket.disconnect();
+        done();
+      });
+      socket.compress(false).emit('hi');
+    });
+  });
 });


### PR DESCRIPTION
Support compression and add the compress method which user can set the compress flag for a subsequent event emission.

Note: `compress(false)` actually does _not_ work for browsers because WS API has no option to disable the compression.

Related: https://github.com/Automattic/socket.io/pull/1958
