### PR TITLE
Fix relative path error when connect to server port - Update socket.io.js

### DIFF
--- a/socket.io.js
+++ b/socket.io.js
@@ -1053,7 +1053,7 @@ function url(uri, loc){
       if ('/' == uri.charAt(1)) {
         uri = loc.protocol + uri;
       } else {
-        uri = loc.hostname + uri;
+        uri = loc.host + uri;
       }
     }
 


### PR DESCRIPTION
fix the relative path bug at line 1056
here should be location.host,not location.hostname.
hostname is only a domain name without port, but location.host is a full url.
I have test on server like xxx.com:9000.
Refer to https://developer.mozilla.org/zh-CN/docs/Web/API/Location:
 URLUtils.protocol
    Is a DOMString containing the protocol scheme of the URL, including the final ':'.
URLUtils.host
    Is a DOMString containing the host, that is the hostname, a ':', and the port of the URL.
URLUtils.hostname
    Is a DOMString containing the domain of the URL.