### PR TITLE
fix for npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "debug": "0.7.4",
-    "engine.io-client": "automattic/engine.io-client#90b72d",
+    "engine.io-client": "automattic/engine.io-client#cdd97fa",
     "component-bind": "1.0.0",
     "component-emitter": "1.1.2",
     "object-component": "0.0.3",


### PR DESCRIPTION
fix for npm install to force correct revision of engine.io-client with correct ws version.